### PR TITLE
Upgrade for ghc 9.6 and 9.8

### DIFF
--- a/jl.cabal
+++ b/jl.cabal
@@ -13,6 +13,9 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
+flag AttoParsecAeson
+  description: Data.Aeson.Parser was moved to a separate package with Aeson 2.2
+
 library
   hs-source-dirs:      src
   ghc-options:         -Wall  -O2
@@ -34,5 +37,9 @@ executable jl
   main-is:             Main.hs
   ghc-options:         -Wall -O2 -static
   build-depends:       base
-                     , jl, text, aeson >=2, aeson-pretty, containers, bytestring, mtl, optparse-simple, vector, conduit, conduit-extra
+                     , jl, text, aeson-pretty, containers, bytestring, mtl, optparse-simple, vector, conduit, conduit-extra
+  if flag(AttoParsecAeson)
+    build-depends:     aeson >=2.2, attoparsec-aeson
+  else
+    build-depends:     aeson <2.2
   default-language:    Haskell2010

--- a/src/JL/Inferer.hs
+++ b/src/JL/Inferer.hs
@@ -8,6 +8,7 @@
 module JL.Inferer where
 
 
+import           Control.Monad (foldM)
 import           Control.Monad.State.Strict
 import qualified Data.HashMap.Strict as HM
 import           Data.Map (Map)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,6 @@
-resolver: lts-19.6
+resolver: lts-22.13
+
+# Remove this when upgrading to lts-23
+flags:
+  jl:
+    AttoParsecAeson: false


### PR DESCRIPTION
* Data.Aeson.Parser was moved to a separate package with Aeson 2.2
* foldM is no longer re-exported by Control.Monad.State.Strict
* The project is now also compatible with ghc 9.8 (eg using a nightly stackage)
* The flag in the Cabal file needs to be set explicitly when using stack